### PR TITLE
feat: write cached segments to storage on log synced

### DIFF
--- a/node/chunk_pool/src/mem_pool/chunk_write_control.rs
+++ b/node/chunk_pool/src/mem_pool/chunk_write_control.rs
@@ -16,6 +16,7 @@ enum SlotStatus {
 /// limit on writing threads per file. Meanwhile, the left_boundary field records
 /// how many segments have been uploaded.
 struct CtrlWindow {
+    #[allow(unused)]
     size: usize,
     left_boundary: usize,
     slots: HashMap<usize, SlotStatus>,

--- a/node/router/src/libp2p_event_handler.rs
+++ b/node/router/src/libp2p_event_handler.rs
@@ -380,7 +380,7 @@ impl Libp2pEventHandler {
         }
 
         // TODO(qhz): check if there is better way to check existence of requested chunks.
-        let _ = match self
+        match self
             .store
             .get_chunks_by_tx_and_index_range(
                 msg.tx_id.seq,

--- a/node/sync/src/service.rs
+++ b/node/sync/src/service.rs
@@ -154,7 +154,7 @@ impl SyncService {
         let store = Store::new(store, executor.clone());
 
         let manager =
-            AutoSyncManager::new(store.clone(), sync_send.clone(), config.clone()).await?;
+            AutoSyncManager::new(store.clone(), sync_send.clone(), config).await?;
         if config.auto_sync_enabled {
             manager.spwn(&executor, event_recv);
         }

--- a/tests/cache_test.py
+++ b/tests/cache_test.py
@@ -17,7 +17,7 @@ class ExampleTest(TestFramework):
         self.contract.submit(submissions)
         wait_until(lambda: self.contract.num_submissions() == 1)
         wait_until(lambda: client.zgs_get_file_info(data_root) is not None)
-        wait_until(lambda: client.zgs_get_file_info(data_root)["isCached"])
+        wait_until(lambda: not client.zgs_get_file_info(data_root)["isCached"] and client.zgs_get_file_info(data_root)["uploadedSegNum"] == 1)
         client.zgs_upload_segment(segments[1])
         wait_until(lambda: client.zgs_get_file_info(data_root)["finalized"])
 

--- a/tests/crash_test.py
+++ b/tests/crash_test.py
@@ -22,6 +22,7 @@ class CrashTest(TestFramework):
         self.log.info("segment: %s", segment)
 
         for i in range(self.num_nodes):
+            self.nodes[i].admin_start_sync_file(0)
             self.log.info("wait for node: %s", i)
             wait_until(
                 lambda: self.nodes[i].zgs_get_file_info(data_root) is not None

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -17,7 +17,7 @@ class RandomTest(TestFramework):
         self.num_blockchain_nodes = 1
         self.num_nodes = 4
         for i in range(self.num_nodes):
-            self.zgs_node_configs[i] = {"find_peer_timeout_secs": 1, "confirmation_block_count": 1}
+            self.zgs_node_configs[i] = {"find_peer_timeout_secs": 1, "confirmation_block_count": 1, "sync": {"auto_sync_enabled": True}}
 
     def run_test(self):
         max_size = 256 * 1024 * 64


### PR DESCRIPTION
- Write cached segments into storage on event log is synced, even though the uploaded file is not complete
- Fix python tests