### PR TITLE
Rpc enhancements

### DIFF
--- a/node/rpc/src/admin/api.rs
+++ b/node/rpc/src/admin/api.rs
@@ -20,6 +20,10 @@ pub trait Rpc {
         end_index: u64, // exclusive
     ) -> RpcResult<()>;
 
+    /// Terminate file or chunks sync for specified tx_seq.
+    #[method(name = "terminateSync")]
+    async fn terminate_sync(&self, tx_seq: u64) -> RpcResult<()>;
+
     #[method(name = "getSyncStatus")]
     async fn get_sync_status(&self, tx_seq: u64) -> RpcResult<String>;
 

--- a/node/rpc/src/admin/impl.rs
+++ b/node/rpc/src/admin/impl.rs
@@ -78,6 +78,24 @@ impl RpcServer for RpcServerImpl {
     }
 
     #[tracing::instrument(skip(self), err)]
+    async fn terminate_sync(&self, tx_seq: u64) -> RpcResult<()> {
+        info!("admin_terminateSync({tx_seq})");
+
+        let response = self
+            .ctx
+            .request_sync(SyncRequest::TerminateFileSync {
+                tx_seq,
+                is_reverted: false,
+            })
+            .await?;
+
+        match response {
+            SyncResponse::TerminateFileSync { .. } => Ok(()),
+            _ => Err(error::internal_error("unexpected response type")),
+        }
+    }
+
+    #[tracing::instrument(skip(self), err)]
     async fn get_sync_status(&self, tx_seq: u64) -> RpcResult<String> {
         info!("admin_getSyncStatus({tx_seq})");
 

--- a/node/rpc/src/config.rs
+++ b/node/rpc/src/config.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 pub struct Config {
     pub enabled: bool,
     pub listen_address: SocketAddr,
-    pub listen_address_admin: SocketAddr,
+    pub listen_address_admin: Option<SocketAddr>,
     pub chunks_per_segment: usize,
     pub max_cache_file_size: usize,
 }

--- a/node/rpc/src/config.rs
+++ b/node/rpc/src/config.rs
@@ -4,6 +4,7 @@ use std::net::SocketAddr;
 pub struct Config {
     pub enabled: bool,
     pub listen_address: SocketAddr,
+    pub listen_address_admin: SocketAddr,
     pub chunks_per_segment: usize,
     pub max_cache_file_size: usize,
 }

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -19,6 +19,7 @@ use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
 use network::NetworkGlobals;
 use network::NetworkMessage;
 use std::error::Error;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use storage_async::Store;
 use sync::{SyncRequest, SyncResponse, SyncSender};
@@ -60,38 +61,61 @@ impl Context {
     }
 }
 
-pub async fn run_server(ctx: Context) -> Result<HttpServerHandle, Box<dyn Error>> {
-    let server = HttpServerBuilder::default()
-        .build(ctx.config.listen_address)
-        .await?;
+pub async fn run_server(ctx: Context) -> Result<(HttpServerHandle, Option<HttpServerHandle>), Box<dyn Error>> {
+    let handles = match ctx.config.listen_address_admin {
+        Some(listen_addr_private) => run_server_public_private(ctx, listen_addr_private).await?,
+        None => (run_server_all(ctx).await?, None),
+    };
 
-    // public rpc
-    let zgs = (zgs::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
+    info!("Server started");
 
-    let addr = server.local_addr()?;
-    let handle = server.start(zgs)?;
-    info!("Server started http://{}", addr);
-
-    Ok(handle)
+    Ok(handles)
 }
 
-pub async fn run_server_admin(ctx: Context) -> Result<HttpServerHandle, Box<dyn Error>> {
-    let server = HttpServerBuilder::default()
-        .build(ctx.config.listen_address_admin)
-        .await?;
+/// Run a single RPC server for all namespace RPCs.
+async fn run_server_all(ctx: Context) -> Result<HttpServerHandle, Box<dyn Error>> {
+    // public rpc
+    let mut zgs = (zgs::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
+    
+    // admin rpc
+    let admin = (admin::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
+    zgs.merge(admin)?;
+
+    // mine rpc if configured
+    if ctx.mine_service_sender.is_some() {
+        let mine = (miner::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
+        zgs.merge(mine)?;
+    }
+
+    Ok(HttpServerBuilder::default()
+        .build(ctx.config.listen_address)
+        .await?
+        .start(zgs)?)
+}
+
+/// Run 2 RPC servers (public & private) for different namespace RPCs.
+async fn run_server_public_private(ctx: Context, listen_addr_private: SocketAddr) -> Result<(HttpServerHandle, Option<HttpServerHandle>), Box<dyn Error>> {
+    // public rpc
+    let zgs = (zgs::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
 
     // admin rpc
     let mut admin = (admin::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
 
     // mine rpc if configured
     if ctx.mine_service_sender.is_some() {
-        let mine = (miner::RpcServerImpl { ctx }).into_rpc();
+        let mine = (miner::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
         admin.merge(mine)?;
     }
 
-    let addr = server.local_addr()?;
-    let handle = server.start(admin)?;
-    info!("Server (admin) started http://{}", addr);
+    let handle_public = HttpServerBuilder::default()
+        .build(ctx.config.listen_address)
+        .await?
+        .start(zgs)?;
 
-    Ok(handle)
+    let handle_private = HttpServerBuilder::default()
+        .build(listen_addr_private)
+        .await?
+        .start(admin)?;
+
+    Ok((handle_public, Some(handle_private)))
 }

--- a/node/rpc/src/lib.rs
+++ b/node/rpc/src/lib.rs
@@ -61,7 +61,9 @@ impl Context {
     }
 }
 
-pub async fn run_server(ctx: Context) -> Result<(HttpServerHandle, Option<HttpServerHandle>), Box<dyn Error>> {
+pub async fn run_server(
+    ctx: Context,
+) -> Result<(HttpServerHandle, Option<HttpServerHandle>), Box<dyn Error>> {
     let handles = match ctx.config.listen_address_admin {
         Some(listen_addr_private) => run_server_public_private(ctx, listen_addr_private).await?,
         None => (run_server_all(ctx).await?, None),
@@ -76,7 +78,7 @@ pub async fn run_server(ctx: Context) -> Result<(HttpServerHandle, Option<HttpSe
 async fn run_server_all(ctx: Context) -> Result<HttpServerHandle, Box<dyn Error>> {
     // public rpc
     let mut zgs = (zgs::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
-    
+
     // admin rpc
     let admin = (admin::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
     zgs.merge(admin)?;
@@ -94,7 +96,10 @@ async fn run_server_all(ctx: Context) -> Result<HttpServerHandle, Box<dyn Error>
 }
 
 /// Run 2 RPC servers (public & private) for different namespace RPCs.
-async fn run_server_public_private(ctx: Context, listen_addr_private: SocketAddr) -> Result<(HttpServerHandle, Option<HttpServerHandle>), Box<dyn Error>> {
+async fn run_server_public_private(
+    ctx: Context,
+    listen_addr_private: SocketAddr,
+) -> Result<(HttpServerHandle, Option<HttpServerHandle>), Box<dyn Error>> {
     // public rpc
     let zgs = (zgs::RpcServerImpl { ctx: ctx.clone() }).into_rpc();
 

--- a/node/src/client/builder.rs
+++ b/node/src/client/builder.rs
@@ -236,11 +236,15 @@ impl ClientBuilder {
             mine_service_sender: mine_send,
         };
 
-        let rpc_handle = rpc::run_server(ctx)
+        let rpc_handle = rpc::run_server(ctx.clone())
             .await
             .map_err(|e| format!("Unable to start HTTP RPC server: {:?}", e))?;
+        let admin_rpc_handle = rpc::run_server_admin(ctx)
+            .await
+            .map_err(|e| format!("Unable to start HTTP admin RPC server: {:?}", e))?;
 
         executor.spawn(rpc_handle, "rpc");
+        executor.spawn(admin_rpc_handle, "rpc_admin");
         executor.spawn(chunk_pool_handler.run(), "chunk_pool_handler");
         executor.spawn(
             MemoryChunkPool::monitor_log_entry(chunk_pool_clone, synced_tx_recv),

--- a/node/src/config/convert.rs
+++ b/node/src/config/convert.rs
@@ -63,9 +63,15 @@ impl ZgsConfig {
             .parse::<std::net::SocketAddr>()
             .map_err(|e| format!("Unable to parse rpc_listen_address: {:?}", e))?;
 
+        let listen_address_admin = self
+            .rpc_listen_address_admin
+            .parse::<std::net::SocketAddr>()
+            .map_err(|e| format!("Unable to parse rpc_listen_address_admin: {:?}", e))?;
+
         Ok(RPCConfig {
             enabled: self.rpc_enabled,
             listen_address,
+            listen_address_admin,
             chunks_per_segment: self.rpc_chunks_per_segment,
             max_cache_file_size: self.rpc_max_cache_file_size,
         })

--- a/node/src/config/convert.rs
+++ b/node/src/config/convert.rs
@@ -63,13 +63,14 @@ impl ZgsConfig {
             .parse::<std::net::SocketAddr>()
             .map_err(|e| format!("Unable to parse rpc_listen_address: {:?}", e))?;
 
-        let listen_address_admin = if self.rpc_listen_address_admin.len() == 0 {
+        let listen_address_admin = if self.rpc_listen_address_admin.is_empty() {
             None
         } else {
-            Some(self
-                .rpc_listen_address_admin
-                .parse::<std::net::SocketAddr>()
-                .map_err(|e| format!("Unable to parse rpc_listen_address_admin: {:?}", e))?)
+            Some(
+                self.rpc_listen_address_admin
+                    .parse::<std::net::SocketAddr>()
+                    .map_err(|e| format!("Unable to parse rpc_listen_address_admin: {:?}", e))?,
+            )
         };
 
         Ok(RPCConfig {

--- a/node/src/config/convert.rs
+++ b/node/src/config/convert.rs
@@ -63,10 +63,14 @@ impl ZgsConfig {
             .parse::<std::net::SocketAddr>()
             .map_err(|e| format!("Unable to parse rpc_listen_address: {:?}", e))?;
 
-        let listen_address_admin = self
-            .rpc_listen_address_admin
-            .parse::<std::net::SocketAddr>()
-            .map_err(|e| format!("Unable to parse rpc_listen_address_admin: {:?}", e))?;
+        let listen_address_admin = if self.rpc_listen_address_admin.len() == 0 {
+            None
+        } else {
+            Some(self
+                .rpc_listen_address_admin
+                .parse::<std::net::SocketAddr>()
+                .map_err(|e| format!("Unable to parse rpc_listen_address_admin: {:?}", e))?)
+        };
 
         Ok(RPCConfig {
             enabled: self.rpc_enabled,

--- a/node/src/config/mod.rs
+++ b/node/src/config/mod.rs
@@ -37,6 +37,7 @@ build_config! {
     // rpc
     (rpc_enabled, (bool), true)
     (rpc_listen_address, (String), "127.0.0.1:5678".to_string())
+    (rpc_listen_address_admin, (String), "127.0.0.1:5679".to_string())
     (rpc_chunks_per_segment, (usize), 1024)
     (rpc_max_cache_file_size, (usize), 10*1024*1024) //10MB
 

--- a/node/sync/src/service.rs
+++ b/node/sync/src/service.rs
@@ -574,24 +574,9 @@ impl SyncService {
             }
         };
 
-        // trigger retry after failure
-        if let SyncState::Failed { .. } = controller.get_status() {
-            let goal = controller.get_sync_info().goal;
-
-            match maybe_range {
-                Some((start, end)) => {
-                    if goal.is_all_chunks() || start != goal.index_start || end != goal.index_end {
-                        bail!("Cannot change failed file sync to chunks sync");
-                    }
-                }
-                None => {
-                    if !goal.is_all_chunks() {
-                        bail!("Cannot change failed chunks sync to file sync");
-                    }
-                }
-            }
-
-            controller.reset();
+        // Trigger file or chunks sync again if completed or failed.
+        if controller.is_completed_or_failed() {
+            controller.reset(maybe_range);
         }
 
         if let Some((peer_id, addr)) = maybe_peer {

--- a/run/config.toml
+++ b/run/config.toml
@@ -15,6 +15,7 @@ db_dir = "db"
 
 rpc_enabled = true
 rpc_listen_address = "0.0.0.0:5678"
+# rpc_listen_address_admin = "127.0.0.1:5679"
 
 log_config_file = "log_config"
 

--- a/tests/test_framework/zgs_node.py
+++ b/tests/test_framework/zgs_node.py
@@ -39,6 +39,7 @@ class ZgsNode(TestNode):
             "network_libp2p_port": p2p_port(index),
             "network_discovery_port": p2p_port(index),
             "rpc_listen_address": f"127.0.0.1:{rpc_port(index)}",
+            "rpc_listen_address_admin": "",
             "network_libp2p_nodes": libp2p_nodes,
             "log_contract_address": log_contract_address,
             "mine_contract_address": mine_contract_address,


### PR DESCRIPTION
1. Add rpc `admin_terminateSync` to terminate file/chunks sync.
2. When p2p sync failed, do not allow to resync if goal changed.
3. Support to configure separate endpoint for admin and mine rpc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zero-gravity-labs/zerog-storage-rust/15)
<!-- Reviewable:end -->
